### PR TITLE
Update chapter2.ipynb

### DIFF
--- a/src/code/chapter2.ipynb
+++ b/src/code/chapter2.ipynb
@@ -52,6 +52,7 @@
     "# 不管是哪个厂商的ChatModel，初始化参数都类似（model、temperature等）\n",
     "chat_model = ChatOpenAI(\n",
     "    model=\"deepseek-chat\",  # 选择对话模型\n",
+    "    api_key=API_KEY,\n",
     "    base_url=BASE_URL,\n",
     "    temperature=0.3,        # 随机性：0-1，越小越严谨，越大越有创造力\n",
     "    max_tokens=200          # 最大生成 tokens 数，避免生成过长内容\n",


### PR DESCRIPTION
2.1.2(1)调用OpenAI的ChatModel的第一块代码缺少api_key=API_KEY，导致代码奔溃，增加了一行代码