### PR TITLE
docs(guide): 更新文档中多模型配置说明

### DIFF
--- a/docs/guide/chapter1.md
+++ b/docs/guide/chapter1.md
@@ -244,20 +244,21 @@ OpenAI版本： 2.31.0
 
 | 服务商                 | 官网                                        |
 | ------------------- | ----------------------------------------- |
-| **DeepSeek**        | <https://platform.deepseek.com/usage>     |
+| **DeepSeek**        | <https://platform.deepseek.com/usage>     | 
 | **通义千问（Qwen）**      | <https://bailian.console.aliyun.com/>     |
-| **ChatGPT（OpenAI）** | <https://chatgpt.com/>                    |
-| **智谱 AI（GLM）**      | <https://bigmodel.cn/>                    |
-| **硅基流动**            | <https://cloud.siliconflow.cn/> |
+| **ChatGPT（OpenAI）** | <https://chatgpt.com/>                    | 
+| **智谱 AI（GLM）**      | <https://bigmodel.cn/>                    | 
+| **硅基流动**            | <https://cloud.siliconflow.cn/> | 
 
-> 本教程选择的是deepseek官网的api，可以根据个人情况选择不同的底座模型
+> 💡 **提示**：本教程默认使用 DeepSeek，但所有代码都兼容其他 OpenAI 兼容接口的模型。详细的多模型配置说明请参考 **[第2章](chapter2.md)**（见 2.1.4 节）。
+
 
 在项目文件夹（easy-langent）中新建一个文件，**命名为".env"**（注意前面有个点），或者直接复制根目录下的 `.env.example` 模板文件，然后修改文件名为 `.env`。
 > Tips: windows系统会存在隐藏扩展名的问题，新建`.env`时，需要点击【查看】->【显示】->勾选【文件扩展名】，才能看到隐藏扩展名。
 
 **步骤3.1：编辑.env文件**
 
-用编辑器打开`.env文件`，写入以下内容（替换成你的API密钥）：
+用编辑器打开`.env文件`，根据你的模型提供商写入以下内容（替换成你的API密钥）：
 
 ```env
 API_KEY="YOUR_API_KEY"

--- a/docs/guide/chapter2.md
+++ b/docs/guide/chapter2.md
@@ -262,6 +262,53 @@ Hugging Face模型回复：
 
 看到了吧？不管是OpenAI还是Hugging Face的模型，调用逻辑都是“初始化模型→构造输入→invoke()调用→输出结果”，这就是统一接口的好处。后续开发中，你可以根据项目需求（比如成本、隐私要求）灵活切换模型，不用大幅修改代码。
 
+#### （4）快速切换其他主流服务商
+
+得益于 LangChain 的统一接口设计，切换到其他主流服务商非常简单，只需要修改 `.env` 文件中的配置，然后在代码中修改 `model` 参数即可。
+
+##### ① 通义千问（Qwen）
+
+在 `.env` 文件中配置：
+```env
+API_KEY="YOUR_API_KEY"
+BASE_URL="https://dashscope.aliyuncs.com/compatible-mode/v1"
+MODEL="qwen-plus"
+```
+
+然后在代码中修改 `model` 参数：
+```python
+llm = ChatOpenAI(
+    api_key=API_KEY,
+    base_url=BASE_URL,
+    model="qwen-plus",  # 改为 qwen-plus
+    temperature=0.3
+)
+```
+
+##### ② 智谱 AI（GLM）
+
+在 `.env` 文件中配置：
+```env
+API_KEY="YOUR_API_KEY"
+BASE_URL="https://open.bigmodel.cn/api/paas/v4"
+MODEL="glm-4"
+```
+
+然后在代码中修改 `model` 参数：
+```python
+llm = ChatOpenAI(
+    api_key=API_KEY,
+    base_url=BASE_URL,
+    model="glm-4",  # 改为 glm-4
+    temperature=0.3
+)
+```
+
+> 💡 **提示**：所有 OpenAI 兼容接口的服务商都遵循相同的调用方式，只需修改 `.env` 配置和 `model` 参数即可。
+>
+> **已验证兼容的服务商**：DeepSeek、通义千问（Qwen）、智谱 AI（GLM）。
+
+
 ## 2.2 提示词模板（PromptTemplate）：让提示更规范、可复用
 
 为什么需要提示词模板？比如你想做一个“学习建议生成器”，需要给不同角色（高校学生、程序员、职场人）生成建议。如果每次都写完整的提示词，不仅麻烦，还容易出错（比如漏写关键信息）。


### PR DESCRIPTION
- 在第1章中添加了多模型配置的提示信息和章节引用
- 修改了.env文件编辑说明以支持不同模型提供商
- 在第2章中新增了快速切换主流服务商的详细配置指南
- 添加了通义千问和智谱AI的具体配置示例
- 更新了模型切换的操作说明和兼容性列表