### PR TITLE
[fix] chapter7.md:修复7.2.3.2 retry_count 无效

### DIFF
--- a/docs/guide/chapter6.md
+++ b/docs/guide/chapter6.md
@@ -576,8 +576,9 @@ display(Image(graph.get_graph().draw_mermaid_png()))
 ```python
 #=======循环节点======
 def loop_node(state: TaskState):
-    print("\n🔄 loop_node, progress =", state.progress)
-    return {"progress": state.progress + 30}
+    progress = state.get("progress", 0)
+    print("\n🔄 loop_node, progress =", progress)
+    return {"progress": progress + 30}
 
 #=======循环条件函数======
 def loop_router(state: TaskState):

--- a/docs/guide/chapter7.md
+++ b/docs/guide/chapter7.md
@@ -1599,7 +1599,18 @@ def review_agent(state):
     ) | llm
 
     result = prompt.invoke({"plot": state["plot"]})
-    return {"review_result": result.content.strip().lower()}
+    review_result = result.content.strip().lower()
+    
+    # 在节点中处理计数更新（正确的不可变更新方式）
+    retry_count = state.get("retry_count", 0)
+    if review_result == "retry":
+        retry_count = retry_count + 1
+    
+    return {
+        "review_result": review_result,
+        "retry_count": retry_count
+    }
+    
 
 # ================== 2. 条件分支（增加循环次数限制） ==================
 MAX_RETRIES = 2  # 最大重试次数
@@ -1607,18 +1618,19 @@ MAX_RETRIES = 2  # 最大重试次数
 def decide_next_node(state):
     """
     - 'pass' -> 结束
-    - 'retry' -> 重新生成情节，最多 MAX_RETRIES 次
+    - 'retry' + 未超限 -> 重新生成情节
+    - 'retry' + 超限 -> 标记失败并结束
     """
     retry_count = state.get("retry_count", 0)
-    if state["review_result"] == "pass":
+    review_result = state.get("review_result", "retry")
+    
+    if review_result == "pass":
         return "end"
     elif retry_count >= MAX_RETRIES:
         # 超过最大重试次数，标记失败并结束
-        state["failed"] = True
         return "end"
     else:
-        # 重试次数 +1
-        state["retry_count"] = retry_count + 1
+        # 返回 plot 节点继续重试
         return "plot"
 
 # ================== 3. 构建循环逻辑图 ==================
@@ -1626,7 +1638,10 @@ graph = StateGraph(NovelState)
 
 graph.add_node("plot", plot_agent)
 graph.add_node("review", review_agent)
-graph.add_node("end", lambda state: state)
+graph.add_node("end", lambda state: {
+    **state,
+    "failed": state.get("review_result") != "pass" and state.get("retry_count", 0) >= MAX_RETRIES
+})
 
 graph.add_edge(START, "plot")
 graph.add_edge("plot", "review")


### PR DESCRIPTION
修复原函数decide_next_node重试次数state["retry_count"] = retry_count + 1，无法生效，因为state是状态副本，没有返回不会更新。需要在review_agent更新状态值。