### PR TITLE
Add projects page and link in docs

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -27,7 +27,8 @@ export default defineConfig({
     // https://vitepress.dev/reference/default-theme-config
     nav: [
       { text: '首页', link: '/' },
-      { text: '开始学习', link: '/guide/前言' }
+      { text: '开始学习', link: '/guide/前言' },
+      { text: '实战项目', link: '/projects' }
     ],
 
     sidebar: [

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,5 +21,8 @@ features:
     details: 每一章都配套针对性的实操任务，确保在学习过程中能够动手实践
   - title: 综合实战
     details: 多智能体协作与系统优化，最终完成综合实战项目
+  - title: 实战项目
+    details: 汇总课程优秀智能体 Agent 项目，包含 LangChain 与 LangGraph 实战案例
+    link: /projects
+    linkText: 查看项目合集
 ---
-

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -1,0 +1,23 @@
+# 智能体 Agent 项目合集
+
+## 📌 内测组队学习优秀课程项目
+
+| 项目名称 | 备注 | 作者 |
+| --- | --- | --- |
+| [狼人杀（上帝视角）](https://github.com/datawhalechina/easy-langent/tree/main/project/werewolfGameAi) | 基于langgraph开发 | 内测组 |
+
+## 📌 202604组队学习优秀课程项目
+
+| 项目名称 | 备注 | 作者 |
+| --- | --- | --- |
+| [剧本杀4人版](https://github.com/datawhalechina/easy-langent/tree/main/project/ScriptedMurderGame) | 基于langgraph开发 | winnerFlyer |
+| [智能知识库问答](https://github.com/datawhalechina/easy-langent/tree/main/project/AgenticRag) | 基于langchain开发 | jspi-fu |
+| [MCPChat](https://github.com/datawhalechina/easy-langent/tree/main/project/MCPChat) | 基于langchain开发 | jspi-fu |
+| [数据处理智能体](https://github.com/datawhalechina/easy-langent/tree/main/project/DataAgent) | 基于langchain开发 | jspi-fu |
+| [医疗RAG诊断](https://github.com/datawhalechina/easy-langent/tree/main/project/MedicalRag) | 基于langchain开发 | 道法自然 |
+| [谁是卧底增强版](https://github.com/datawhalechina/easy-langent/tree/main/project/WhoIsTheSpyBaocaiLi) | 基于langgraph开发 | 道法自然 |
+| [个人助手](https://github.com/datawhalechina/easy-langent/tree/main/project/PersonalMemoryAssistant) | 基于langchain开发 | 念安 |
+| [AI面试官](https://github.com/datawhalechina/easy-langent/tree/main/project/RecruitingInterviewAgentDemo) | 基于langgraph开发 | 念安 |
+| [客服工单智能处理](https://github.com/datawhalechina/easy-langent/tree/main/project/TicketReviewAgentDemo) | 基于langgraph开发 | 念安 |
+| [辩论赛4人版](https://github.com/datawhalechina/easy-langent/tree/main/project/DebateGame) | 基于langgraph开发 | WangDF2022 |
+| [哈尔滨冰雪大世界舆情分析](https://github.com/datawhalechina/easy-langent/tree/main/project/HarbinIceSnowOpinionDecision) | 基于langgraph开发 | tian09150714 |


### PR DESCRIPTION
Create docs/projects.md to list and showcase course Agent projects, and update documentation to surface it: add a "实战项目" nav link in .vitepress/config.mts and add a "实战项目" feature block with link in docs/index.md. This exposes the project collection for learners to explore sample LangChain/LangGraph implementations.