### PR TITLE
修复 docs/guide/chapter4.md 中 RunnableMap 示例的 target_audience 传递逻辑

### DIFF
--- a/docs/guide/chapter4.md
+++ b/docs/guide/chapter4.md
@@ -208,11 +208,12 @@ marketing_prompt = PromptTemplate(
 )
 
 # 3. 多输入多输出线性链（教学标准版）
+
 overall_chain = (
     # Step 1：生成卖点 + 透传原始输入
     RunnableMap({
         "sell_points": sell_point_prompt | llm | (lambda x: x.content),
-        "target_audience": RunnablePassthrough(),
+        "target_audience": lambda x: x["target_audience"],
     })
     # Step 2：营销话术生成
     | marketing_prompt


### PR DESCRIPTION
原示例中使用 RunnablePassthrough()，会将完整输入字典传递给 target_audience，
而营销话术生成阶段只需要 target_audience 字段本身。

本次修改将其调整为 lambda x: x["target_audience"]，
使 RunnableMap 输出结构更符合后续 PromptTemplate 的输入预期。